### PR TITLE
Spruce up documentation infrastruture

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,0 +1,6 @@
+{
+  "format": {
+    "dangle_align": "child",
+    "dangle_parens": true
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,62 @@
+# GitHub Copilot Instructions
+
+## Communication Guidelines
+
+### Professional Colleague Interaction
+
+Interact with the developer as a professional colleague, not as a subordinate:
+
+- Avoid sycophancy and obsequiousness
+- Point out mistakes or correct misunderstandings when necessary, using professional and constructive language
+- If the developer's request contains an error or misunderstanding, explain the issue clearly
+
+### Truth and Accuracy
+
+Accuracy and honesty are critical:
+
+- If you lack sufficient information to complete a task, say so explicitly: "I don't know" or "I don't have access to the information needed"
+- Ask the developer for help or additional information when needed
+- Never fabricate answers or hide gaps in knowledge
+- It is better to acknowledge limitations than to provide incorrect information
+
+### Clear and Direct Communication
+
+Be explicit and unambiguous in all responses:
+
+- Use literal language; avoid idioms, metaphors, or figurative expressions that could be misinterpreted
+- State assumptions explicitly rather than leaving them implicit
+- When suggesting multiple options, clearly label them and explain the trade-offs
+- If a request is ambiguous, ask specific clarifying questions before proceeding
+- Provide concrete examples when explaining abstract concepts
+- Break down complex tasks into explicit, numbered steps when helpful
+- If you're uncertain about what the developer wants, state what you understand and ask for confirmation
+
+## Workspace Environment Setup
+
+## Text Formatting Standards
+
+**CRITICAL: Apply to ALL files you create or edit (bash scripts, Python, C++, YAML, Markdown, etc.)**
+
+- All text files must end with exactly one newline character and no trailing blank lines
+- **Never add trailing whitespace on any line** (spaces or tabs at end of lines)
+- This includes blank lines - they should contain only the newline character, no spaces or tabs
+- Exception: Markdown two-space line breaks (avoid; use proper paragraph breaks instead)
+
+## Code Formatting Standards
+
+### CMake Files
+
+- Use cmake-format tool (VS Code auto-formats on save)
+- Configuration: `dangle_align: "child"`, `dangle_parens: true`
+
+## Markdown Rules
+
+All Markdown files must strictly follow these markdownlint rules:
+
+- **MD012**: No multiple consecutive blank lines (never more than one blank line in a row, anywhere)
+- **MD022**: Headings must be surrounded by exactly one blank line before and after
+- **MD031**: Fenced code blocks must be surrounded by exactly one blank line before and after
+- **MD032**: Lists must be surrounded by exactly one blank line before and after (including after headings and code blocks)
+- **MD034**: No bare URLs (for example, use a markdown link like `[text](destination)` instead of a plain URL)
+- **MD036**: Use # headings, not **Bold:** for titles
+- **MD040**: Always specify code block language (for example, use '```bash', '```python', '```text', etc.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,20 @@
-cmake_minimum_required(VERSION 3.18.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24..4.1.2 FATAL_ERROR)
 
-find_package(cetmodules 3.23.00 REQUIRED)
-project(spack-at-fnal VERSION 0.00.01 LANGUAGES)
+# ##############################################################################
+# Ensure we have access to a suitable version of Cetmodules
+include(FetchContent)
+FetchContent_Declare(
+  cetmodules
+  GIT_REPOSITORY https://github.com/FNALssi/cetmodules
+  GIT_TAG 4.01.01
+  GIT_SHALLOW ON
+  FIND_PACKAGE_ARGS 4.01.01
+  )
+FetchContent_MakeAvailable(cetmodules)
+find_package(cetmodules 4.01.01 REQUIRED)
+# ##############################################################################
+
+project(spack-at-fnal VERSION 0.00.01 LANGUAGES NONE)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,55 +1,13 @@
 {
-   "configurePresets" : [
-      {
-         "cacheVariables" : {},
-         "description" : "Configuration settings translated from ups/product_deps",
-         "displayName" : "Configuration from product_deps",
-         "hidden" : true,
-         "name" : "from_product_deps"
-      },
-      {
-         "cacheVariables" : {
-            "WANT_UPS" : {
-               "type" : "BOOL",
-               "value" : true
-            },
-            "spack-at-fnal_EXEC_PREFIX_INIT" : {
-               "type" : "STRING",
-               "value" : "$env{CETPKG_FQ_DIR}"
-            },
-            "spack-at-fnal_UPS_BUILD_ONLY_DEPENDENCIES_INIT" : {
-               "type" : "STRING",
-               "value" : "cetmodules;git;python;sphinx"
-            },
-            "spack-at-fnal_UPS_PRODUCT_FLAVOR_INIT" : {
-               "type" : "STRING",
-               "value" : "$env{CETPKG_FLAVOR}"
-            },
-            "spack-at-fnal_UPS_PRODUCT_NAME_INIT" : {
-               "type" : "STRING",
-               "value" : "spack_at_fnal"
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": false,
+            "cacheVariables": {
+                "CMAKE_PROJECT_TOP_LEVEL_INCLUDES": "CetProvideDependency",
+                "BUILD_DOCS": "ON"
             }
-         },
-         "description" : "Extra configuration for UPS package generation",
-         "displayName" : "UPS extra configuration",
-         "hidden" : true,
-         "name" : "extra_for_UPS"
-      },
-      {
-         "description" : "Default configuration including settings from ups/product_deps",
-         "displayName" : "Default configuration",
-         "inherits" : "from_product_deps",
-         "name" : "default"
-      },
-      {
-         "description" : "Default configuration for UPS package generation",
-         "displayName" : "Default configuration for UPS",
-         "inherits" : [
-            "default",
-            "extra_for_UPS"
-         ],
-         "name" : "for_UPS"
-      }
-   ],
-   "version" : 3
+        }
+    ],
+    "version": 3
 }

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -54,26 +54,6 @@ html_favicon = "@CMAKE_CURRENT_SOURCE_DIR@/static/FNALssi-favicon.ico"
 
 html_show_sourcelink = True
 html_theme = "sphinx_rtd_theme"
-html_theme_options = {
-    "bgcolor":          "#ffffff",
-    "codebgcolor":      "#eeeeee",
-    "codetextcolor":    "#333333",
-    "footerbgcolor":    "#00182d",
-    "footertextcolor":  "#ffffff",
-    "headbgcolor":      "#f2f2f2",
-    "headlinkcolor":    "#3d8ff2",
-    "headtextcolor":    "#003564",
-    "linkcolor":        "#2b63a8",
-    "relbarbgcolor":    "#00529b",
-    "relbarlinkcolor":  "#ffffff",
-    "relbartextcolor":  "#ffffff",
-    "sidebarbgcolor":   "#e4ece8",
-    "sidebarbtncolor":  "#00a94f",
-    "sidebarlinkcolor": "#00a94f",
-    "sidebartextcolor": "#333333",
-    "textcolor":        "#444444",
-    "visitedlinkcolor": "#2b63a8",
-}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+sphinx-design>=0.2.0
+sphinx-rtd-theme
+sphinx>=8
+sphinxcontrib-jquery
+sphinxcontrib-moderncmakedomain>=3.25

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,15 +5,12 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - cetmodules@develop
   - 'cmake@3.24.0:'
-  - 'git@2.22:'
-  - gmake
+  - 'git@2.50:'
   - ninja
   - 'py-sphinx-design@0.2.0:'
   - py-sphinx-rtd-theme
-  - py-sphinx-toolbox
-  - 'py-sphinx@6: ^python@:3.12'
+  - 'py-sphinx@8:'
   - py-sphinxcontrib-jquery
   - 'py-sphinxcontrib-moderncmakedomain@3.25:'
   concretizer:


### PR DESCRIPTION
- Basic GitHub Copilot instructions.
- Obtain Cetmodules via `FetchContent`.
- Update dependencies in `spack.yaml`, remove unnecessary extensions.
- Remove inapposite `html_theme_options` from `conf.py.in`.
- `requirements.txt` describes dependencies for easy use by `pip` or
  Conda.
- Simplify `CMakePresets.cmake`
